### PR TITLE
Preserve openerTabId for newly created tab in order to know the parent

### DIFF
--- a/src/background/container.js
+++ b/src/background/container.js
@@ -158,6 +158,9 @@ class Container {
           if (tab.pinned && !dontPin) {
             newTabOptions.pinned = true;
           }
+          if (tab.openerTabId) {
+            newTabOptions.openerTabId = tab.openerTabId;
+          }
         }
 
         debug('[createTabInTempContainer] creating tab in temporary container', newTabOptions);


### PR DESCRIPTION
Fixes #73 