### PR TITLE
Rewrite option for Subdomain isolation

### DIFF
--- a/src/ui/options.html
+++ b/src/ui/options.html
@@ -126,8 +126,8 @@
             <div class="field">
               <select id="isolationGlobal" class="ui fluid dropdown">
                 <option value="always">Always</option>
-                <option value="notsamedomainexact">If the navigation target doesn't exactly match the current Tabs Website Domain</option>
-                <option value="notsamedomain">If the navigation target doesn't match the current Tabs Website Domain (includes Subdomains)</option>
+                <option value="notsamedomainexact">If the navigation target doesn't exactly match the current Tab's Website Domain (Subdomains will be isolated)</option>
+                <option value="notsamedomain">If the navigation target doesn't match the current Tab's Website Domain (Subdomains will be ignored)</option>
                 <option value="never">Never</option>
               </select>
             </div>
@@ -148,8 +148,8 @@
             <div class="field">
               <select id="isolationDomainAction" class="ui fluid dropdown">
                 <option value="always">Always</option>
-                <option value="notsamedomainexact" selected="selected">If the navigation target doesn't exactly match the current Tabs Website Domain</option>
-                <option value="notsamedomain">If the navigation target doesn't match the current Tabs Website Domain (includes Subdomains)</option>
+                <option value="notsamedomainexact" selected="selected">If the navigation target doesn't exactly match the current Tabs Website Domain (Subdomains will be isolated)</option>
+                <option value="notsamedomain">If the navigation target doesn't match the current Tabs Website Domain (Subdomains will be ignored)</option>
                 <option value="never">Never</option>
               </select>
             </div>
@@ -200,8 +200,8 @@
               <label>Middle Mouse</label>
               <select id="linkClickGlobalMiddle" class="ui fluid dropdown">
                 <option value="always">Always</option>
-                <option value="notsamedomainexact">If the clicked Link is not the exact same Domain as the Website</option>
-                <option value="notsamedomain">If the clicked Link is not the same Domain (includes Subdomains) as the Website</option>
+                <option value="notsamedomainexact">If the navigation target doesn't exactly match the current Tabs Website Domain (Subdomains will be isolated)</option>
+                <option value="notsamedomain">If the navigation target doesn't exactly match the current Tabs Website Domain (Subdomains will be ignored)</option>
                 <option value="never">Never</option>
               </select>
             </div>
@@ -209,8 +209,8 @@
               <label>Ctrl/Cmd+Left Mouse</label>
               <select id="linkClickGlobalCtrlLeft" class="ui fluid dropdown">
                 <option value="always">Always</option>
-                <option value="notsamedomainexact">If the clicked Link is not the exact same Domain as the Website</option>
-                <option value="notsamedomain">If the clicked Link is not the same Domain as the Website (includes Subdomains)</option>
+                <option value="notsamedomainexact">If the navigation target doesn't exactly match the current Tabs Website Domain (Subdomains will be isolated)</option>
+                <option value="notsamedomain">If the navigation target doesn't exactly match the current Tabs Website Domain (Subdomains will be ignored)</option>
                 <option value="never">Never</option>
               </select>
             </div>
@@ -218,8 +218,8 @@
               <label>Left Mouse</label>
               <select id="linkClickGlobalLeft" class="ui fluid dropdown">
                 <option value="always">Always</option>
-                <option value="notsamedomainexact">If the clicked Link is not the exact same Domain as the Website</option>
-                <option value="notsamedomain">If the clicked Link is not the same Domain as the Website (includes Subdomains)</option>
+                <option value="notsamedomainexact">If the navigation target doesn't exactly match the current Tabs Website Domain (Subdomains will be ignored)</option>
+                <option value="notsamedomain">If the navigation target doesn't exactly match the current Tabs Website Domain (Subdomains will be ignored)</option>
                 <option value="never">Never</option>
               </select>
             </div>
@@ -241,8 +241,8 @@
               <label>Middle Mouse</label>
               <select id="linkClickDomainMiddle" class="ui fluid dropdown">
                 <option value="always" selected="selected">Always</option>
-                <option value="notsamedomainexact">If the clicked Link is not the exact same Domain as the Website</option>
-                <option value="notsamedomain">If the clicked Link is not the same Domain as the Website (includes Subdomains)</option>
+                <option value="notsamedomainexact">If the navigation target doesn't exactly match the current Tabs Website Domain (Subdomains will be isolated)</option>
+                <option value="notsamedomain">If the navigation target doesn't exactly match the current Tabs Website Domain (Subdomains will be ignored)</option>
                 <option value="never">Never</option>
               </select>
             </div>
@@ -250,8 +250,8 @@
               <label>Ctrl/Cmd+Left Mouse</label>
               <select id="linkClickDomainCtrlLeft" class="ui fluid dropdown">
                 <option value="always" selected="selected">Always</option>
-                <option value="notsamedomainexact">If the clicked Link is not the exact same Domain as the Website</option>
-                <option value="notsamedomain">If the clicked Link is not the same Domain as the Website (includes Subdomains)</option>
+                <option value="notsamedomainexact">If the navigation target doesn't exactly match the current Tabs Website Domain (Subdomains will be isolated)</option>
+                <option value="notsamedomain">If the navigation target doesn't exactly match the current Tabs Website Domain (Subdomains will be isolated ignored)</option>
                 <option value="never">Never</option>
               </select>
             </div>
@@ -259,8 +259,8 @@
               <label>Left Mouse</label>
               <select id="linkClickDomainLeft" class="ui fluid dropdown">
                 <option value="always">Always</option>
-                <option value="notsamedomainexact" selected="selected">If the clicked Link is not the exact same Domain as the Website</option>
-                <option value="notsamedomain">If the clicked Link is not the same Domain as the Website (includes Subdomains)</option>
+                <option value="notsamedomainexact" selected="selected">If the navigation target doesn't exactly match the current Tabs Website Domain (Subdomains will be isolated)</option>
+                <option value="notsamedomain">If the navigation target doesn't exactly match the current Tabs Website Domain (Subdomains will be ignored)</option>
                 <option value="never">Never</option>
               </select>
             </div>


### PR DESCRIPTION
As described on #102

Text become -> If the navigation target doesn't exactly match the current Tabs Website Domain (Subdomains will be isolated/ignored)