### PR TITLE
Fix Domain Pattern in popup menu

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -80,7 +80,7 @@ const initialize = async () => {
 
     $.tab('change tab', 'isolation');
 
-    const tabs = await browser.tabs.query({active: true});
+    const tabs = await browser.tabs.query({currentWindow: true, active: true});
     const activeTab = tabs[0];
     if (!activeTab.url.startsWith('http')) {
       $('#actionNone').removeClass('hidden');


### PR DESCRIPTION
Fix Domain Pattern in the popup menu according to the active windows

Without this, in popup menu, Domain Pattern refers to active tab of the first window and not active window