### PR TITLE
Prevent the form on the exports/imports page to submit

### DIFF
--- a/src/ui/shared.js
+++ b/src/ui/shared.js
@@ -421,7 +421,8 @@ window.formatBytes = (bytes, decimals) => {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + sizes[i];
 };
 
-window.exportPreferencesButton = async () => {
+window.exportPreferencesButton = async (e) => {
+  e.preventDefault();
   const date = new Date();
   const dateString = [date.getFullYear(), date.getMonth() + 1, date.getDate()].join('-');
   const timeString = [date.getHours(), date.getMinutes(), date.getSeconds()].join('.');
@@ -443,6 +444,7 @@ window.exportPreferences = async () => {
 };
 
 window.importPreferencesButton = async (e) => {
+  e.preventDefault();
   await importPreferences(e.target.files[0]);
   $(e.target).closest('form').get(0).reset();
 };


### PR DESCRIPTION
I used a form on the exports/imports page and it submits when the user clicks the button to export the preferences. This isn't expected behavior because the form does nothing.
Somehow it worked when the extension was loaded temporarily.