### PR TITLE
refactor: move isolation.active from preferences to storage

### DIFF
--- a/src/background/browseraction.ts
+++ b/src/background/browseraction.ts
@@ -21,7 +21,7 @@ export class BrowserAction {
     if (this.pref.iconColor !== 'default') {
       this.setIcon(this.pref.iconColor);
     }
-    if (!this.pref.isolation.active) {
+    if (!this.background.isolation.getActiveState()) {
       this.addIsolationInactiveBadge();
     }
   }
@@ -62,7 +62,7 @@ export class BrowserAction {
   }
 
   addBadge(tabId: TabId): void {
-    if (!this.pref.isolation.active) {
+    if (!this.background.isolation.getActiveState()) {
       return;
     }
 
@@ -81,7 +81,7 @@ export class BrowserAction {
   }
 
   removeBadge(tabId: TabId): void {
-    if (!this.pref.isolation.active) {
+    if (!this.background.isolation.getActiveState()) {
       return;
     }
 

--- a/src/background/commands.ts
+++ b/src/background/commands.ts
@@ -118,7 +118,7 @@ export class Commands {
         if (!this.pref.keyboardShortcuts.AltI) {
           return;
         }
-        this.background.isolation.setActiveState(!this.pref.isolation.active);
+        this.background.isolation.toggleActiveState();
         break;
     }
   }

--- a/src/background/migration.ts
+++ b/src/background/migration.ts
@@ -143,6 +143,14 @@ export class Migration {
       }
     }
 
+    if (this.updatedFromVersionEqualToOrLessThan('1.8')) {
+      this.debug(
+        '[migrate] updated from version <= 1.8, migrate isolation.active'
+      );
+      this.storage.local.isolation.active = preferences.isolation.active;
+      delete preferences.isolation.active;
+    }
+
     // hint: don't use preferences/storage-defaults here, ^
     // always hardcode, because the defaults change over time.
     // also keep in mind that missing keys get added before migration

--- a/src/background/pageaction.ts
+++ b/src/background/pageaction.ts
@@ -26,7 +26,7 @@ export class PageAction {
     }
 
     let color;
-    if (!this.pref.isolation.active) {
+    if (!this.background.isolation.getActiveState()) {
       color = 'warning-red';
     } else if (
       activatedTab.cookieStoreId ===

--- a/src/background/preferences.ts
+++ b/src/background/preferences.ts
@@ -26,7 +26,6 @@ export class Preferences {
     },
     iconColor: 'default',
     isolation: {
-      active: true,
       automaticReactivateDelay: 0,
       global: {
         navigation: {
@@ -139,11 +138,6 @@ export class Preferences {
     }
     if (oldPreferences.pageAction !== newPreferences.pageAction) {
       this.pageaction.showOrHide();
-    }
-    if (oldPreferences.isolation.active !== newPreferences.isolation.active) {
-      this.background.isolation.handleActiveState(
-        newPreferences.isolation.active
-      );
     }
     if (!this.permissions.notifications && newPreferences.notifications) {
       this.permissions.notifications = true;

--- a/src/background/runtime.ts
+++ b/src/background/runtime.ts
@@ -8,6 +8,7 @@ import { Migration } from './migration';
 import { MouseClick } from './mouseclick';
 import { Preferences } from './preferences';
 import { Storage } from './storage';
+import { Isolation } from './isolation';
 import { Utils } from './utils';
 import { PreferencesSchema, Tab, Debug, RuntimeMessage } from '~/types';
 import { delay } from './lib';
@@ -16,6 +17,7 @@ export class Runtime {
   private background: TemporaryContainers;
   private debug: Debug;
   private storage: Storage;
+  private isolation!: Isolation;
   private pref!: PreferencesSchema;
   private preferences!: Preferences;
   private container!: Container;
@@ -43,6 +45,7 @@ export class Runtime {
     this.contextmenu = this.background.contextmenu;
     this.cleanup = this.background.cleanup;
     this.convert = this.background.convert;
+    this.isolation = this.background.isolation;
     this.utils = this.background.utils;
   }
 
@@ -61,8 +64,13 @@ export class Runtime {
         this.mouseclick.linkClicked(message.payload, sender);
         break;
 
+      case 'saveIsolation':
+        this.debug('[onMessage] saveIsolation');
+        this.isolation.setActiveState(message.payload.isolation.active);
+        break;
+
       case 'savePreferences':
-        this.debug('[onMessage] saving preferences');
+        this.debug('[onMessage] savePreferences');
         await this.preferences.handleChanges({
           oldPreferences: this.pref,
           newPreferences: message.payload.preferences,

--- a/src/background/storage.ts
+++ b/src/background/storage.ts
@@ -31,6 +31,7 @@ export class Storage {
         },
       },
       isolation: {
+        active: true,
         automaticReactivateTargetTime: 0,
       },
       preferences: background.preferences.defaults,

--- a/src/background/tmp.ts
+++ b/src/background/tmp.ts
@@ -39,12 +39,12 @@ export class TemporaryContainers {
   public mouseclick = new MouseClick(this);
   public tabs = new Tabs(this);
   public commands = new Commands(this);
+  public isolation = new Isolation(this);
   public browseraction = new BrowserAction(this);
   public pageaction = new PageAction(this);
   public contextmenu = new ContextMenu(this);
   public cookies = new Cookies(this);
   public scripts = new Scripts(this);
-  public isolation = new Isolation(this);
   public history = new History(this);
   public cleanup = new Cleanup(this);
   public convert = new Convert(this);
@@ -102,6 +102,7 @@ export class TemporaryContainers {
     this.container.initialize();
     this.mouseclick.initialize();
     this.commands.initialize();
+    this.isolation.initialize();
     this.browseraction.initialize();
     this.pageaction.initialize();
     this.contextmenu.initialize();
@@ -109,7 +110,6 @@ export class TemporaryContainers {
     this.scripts.initialize();
     this.statistics.initialize();
     this.mac.initialize();
-    this.isolation.initialize();
     this.history.initialize();
     this.cleanup.initialize();
     this.convert.initialize();

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,7 @@ export interface StorageLocal {
     };
   };
   isolation: {
+    active: boolean;
     automaticReactivateTargetTime: number;
   };
   preferences: PreferencesSchema;
@@ -162,7 +163,6 @@ export interface PreferencesSchema {
   };
   iconColor: ToolbarIconColor;
   isolation: {
-    active: boolean;
     automaticReactivateDelay: number;
     global: IsolationGlobal;
     domain: IsolationDomain[];

--- a/src/ui/components/popup.vue
+++ b/src/ui/components/popup.vue
@@ -97,8 +97,13 @@ export default Vue.extend({
       window.close();
     },
     toggleIsolation(): void {
-      this.app.preferences.isolation.active = !this.app.preferences.isolation
-        .active;
+      this.app.storage.isolation.active = !this.app.storage.isolation.active;
+      browser.runtime.sendMessage({
+        method: 'saveIsolation',
+        payload: {
+          isolation: this.app.storage.isolation,
+        },
+      });
     },
   },
 });
@@ -152,7 +157,7 @@ export default Vue.extend({
               </a>
               <div class="right menu">
                 <a
-                  v-if="app.preferences.isolation.active"
+                  v-if="app.storage.isolation.active"
                   class="item"
                   title="Disable Isolation"
                   @click="toggleIsolation"

--- a/test/background.isolation.test.ts
+++ b/test/background.isolation.test.ts
@@ -364,7 +364,7 @@ preferencesTestSet.map((preferences) => {
                 beforeEach(async () => {
                   bg.tmp.storage.local.preferences.isolation.global.navigation.action =
                     'always';
-                  bg.tmp.storage.local.preferences.isolation.active = true;
+                  bg.tmp.storage.local.isolation.active = true;
                   bg.tmp.storage.local.preferences.keyboardShortcuts.AltI = true;
                   bg.browser.commands.onCommand.addListener.yield(
                     'toggle_isolation'
@@ -407,7 +407,7 @@ preferencesTestSet.map((preferences) => {
                   bg.tmp.storage.local.preferences.isolation.global.navigation.action =
                     'always';
                   bg.tmp.storage.local.preferences.isolation.automaticReactivateDelay = 3;
-                  bg.tmp.storage.local.preferences.isolation.active = true;
+                  bg.tmp.storage.local.isolation.active = true;
                 });
 
                 describe('when isolation is deactivated', () => {
@@ -420,18 +420,14 @@ preferencesTestSet.map((preferences) => {
 
                   it('should not open a Temporary Container when navigating before auto-isolate triggers', async () => {
                     bg.clock.tick(1000);
-                    bg.tmp.storage.local.preferences.isolation.active.should.equal(
-                      false
-                    );
+                    bg.tmp.storage.local.isolation.active.should.equal(false);
                     await navigateTo('https://example.com/moo');
                     bg.browser.tabs.create.should.not.have.been.called;
                   });
 
                   it('should open a Temporary Container when navigating after auto-isolate triggers', async () => {
                     bg.clock.tick(5000);
-                    bg.tmp.storage.local.preferences.isolation.active.should.equal(
-                      true
-                    );
+                    bg.tmp.storage.local.isolation.active.should.equal(true);
                     await navigateTo('https://example.com/moo');
                     bg.browser.tabs.create.should.have.been.called;
                   });

--- a/test/background.test.ts
+++ b/test/background.test.ts
@@ -377,9 +377,7 @@ preferencesTestSet.map((preferences) => {
           background.storage.local.preferences.keyboardShortcuts.AltI = false;
           browser.commands.onCommand.addListener.yield('toggle_isolation');
           await nextTick();
-          background.storage.local.preferences.isolation.active.should.equal(
-            true
-          );
+          background.storage.local.isolation.active.should.equal(true);
         });
         it('should toggle active isolation when AltI preference is enabled', async () => {
           const { tmp: background, browser } = await loadBackground({
@@ -388,9 +386,7 @@ preferencesTestSet.map((preferences) => {
           background.storage.local.preferences.keyboardShortcuts.AltI = true;
           browser.commands.onCommand.addListener.yield('toggle_isolation');
           await nextTick();
-          background.storage.local.preferences.isolation.active.should.equal(
-            false
-          );
+          background.storage.local.isolation.active.should.equal(false);
         });
       });
     });


### PR DESCRIPTION
Centralize isolation state management and storage access
Add isolation helper functions getActiveState, toggleActiveState
Retire unneeded helper function handleActiveState
Initialize isolation before browseraction
Related to #315
Closes #433