### PR TITLE
chore: extract strings from isolation section for translation (#237)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /.web-ext-artifacts
 /dist
 /*.todo
+/.idea

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -2,9 +2,6 @@
   "automaticMode": {
     "message": "Automatic Mode"
   },
-  "optionsSave": {
-    "message": "Save"
-  },
   "optionsNavGeneral": {
     "message": "General"
   },
@@ -157,5 +154,167 @@
   },
   "optionsGeneralToolbarIconColorWhiteSimple": {
     "message": "white (simple)"
+  },
+  "optionsDomainPattern": {
+    "message": "Domain Pattern"
+  },
+  "optionsExclusionPattern": {
+    "message": "Exclusion Pattern"
+  },
+  "optionsIsolationTabGlobal": {
+    "message": "Global"
+  },
+  "optionsIsolationTabPerDomain": {
+    "message": "Per Domain"
+  },
+  "optionsIsolationTabMac": {
+    "message": "Multi-Account Containers"
+  },
+  "optionsIsolationNavigation": {
+    "message": "Navigation"
+  },
+  "optionsIsolationTargetDomain": {
+    "message": "Target Domain"
+  },
+  "optionsIsolationMouseClick": {
+    "message": "Mouse Click"
+  },
+  "optionsIsolationMouseClickLeftMouse": {
+    "message": "Left Mouse",
+    "description": "Left mouse click"
+  },
+  "optionsIsolationMouseClickCtrlLeftMouse": {
+    "message": "Ctrl/Cmd+Left Mouse",
+    "description": "Ctrl or Cmd key + left mouse click"
+  },
+  "optionsIsolationMouseClickMiddleMouse": {
+    "message": "Middle Mouse",
+    "description": "Middle mouse click"
+  },
+  "optionsIsolationExclude": {
+    "message": "Exclude",
+    "description": "verb"
+  },
+  "optionsIsolationDisabled": {
+    "message": "Disabled"
+  },
+  "optionsIsolationEnabled": {
+    "message": "Enabled"
+  },
+  "optionsIsolationGlobalExcludePermanentContainers": {
+    "message": "Exclude Permanent Containers"
+  },
+  "optionsIsolationGlobalExclusionPermanentContainers": {
+    "message": "Permanent Containers to Exclude"
+  },
+  "optionsIsolationGlobalSelectExclusionContainers": {
+    "message": "Select Permanent Containers to Exclude from Isolation"
+  },
+  "optionsIsolationExcludeTargetDomains": {
+    "message": "Exclude Target Domains"
+  },
+  "optionsIsolationNoDomainsExcluded": {
+    "message": "No domains excluded"
+  },
+  "optionsIsolationMacIsolateNonMac": {
+    "message": "Isolate Navigations in Permanent Containers whose Target Domain isn't MAC-\"Always open in\" assigned to that container"
+  },
+  "optionsIsolationPerDomainPatternNoEmpty": {
+    "message": "Domain Pattern can't be empty"
+  },
+  "optionsIsolationPerDomainPatternExists": {
+    "message": "Domain Pattern already exists"
+  },
+  "optionsIsolationPerDomainAlwaysOpenIn": {
+    "message": "Always open in"
+  },
+  "optionsIsolationPerDomainDisableIfNavPermContainer": {
+    "message": "Disable if Navigation in Permanent Containers"
+  },
+  "optionsIsolationPerDomainDisableIfPermContainer": {
+    "message": "Disable in Permanent Containers"
+  },
+  "optionsIsolationPerDomainDisableIfNavTempContainer": {
+    "message": "Disable if Navigation in Temporary Containers"
+  },
+  "optionsIsolationPerDomainDisableIfTempContainer": {
+    "message": "Disable in Temporary Containers"
+  },
+  "optionsIsolationPerDomainSaved": {
+    "message": "Saved"
+  },
+  "optionsIsolationPerDomainAdd": {
+    "message": "Add $PATTERN$",
+    "description": "To finish adding a new domain pattern",
+    "placeholders": {
+      "pattern": {
+        "content": "$1",
+        "example": "Pattern42"
+      }
+    }
+  },
+  "optionsIsolationPerDomainEdit": {
+    "message": "Edit $PATTERN$",
+    "description": "To start editing a domain pattern",
+    "placeholders": {
+      "pattern": {
+        "content": "$1",
+        "example": "TheReallyBeautifulPattern"
+      }
+    }
+  },
+  "optionsIsolationPerDomainDoneEditing": {
+    "message": "Done editing $PATTERN$",
+    "description": "To finish editing a domain pattern",
+    "placeholders": {
+      "pattern": {
+        "content": "$1",
+        "example": "TheWaitWhyArentMyContainersWorkingPattern"
+      }
+    }
+  },
+  "optionsIsolationPerDomainRemove": {
+    "message": "Remove $PATTERN$",
+    "placeholders": {
+      "pattern": {
+        "content": "$1",
+        "example": "TheBestPattern"
+      }
+    }
+  },
+  "optionsIsolationPerDomainRemoveConfirmation": {
+    "message": "Remove $PATTERN$?",
+    "placeholders": {
+      "pattern": {
+        "content": "$1"
+      }
+    }
+  },
+  "optionsIsolationPerDomainNoIsolatedDomainsAdded": {
+    "message": "No Isolated Domains added yet"
+  },
+  "optionsIsolationPerDomainFilterIsolatedDomains": {
+    "message": "Filter Isolated Domains"
+  },
+  "optionsIsolationPerDomainIsolatedDomains": {
+    "message": "Isolated Domains"
+  },
+  "optionsIsolationPerDomainDragTooltip": {
+    "message": "Drag up/down - First in the list matches first"
+  },
+  "optionsIsolationSettingsGlobal": {
+    "message": "Use Global"
+  },
+  "optionsIsolationSettingsNotSameDomain": {
+    "message": "Different from Tab Domain & Subdomains"
+  },
+  "optionsIsolationSettingsNotSameDomainExact": {
+    "message": "Different from Tab Domain"
+  },
+  "optionsIsolationSettingsAlways": {
+    "message": "Always"
+  },
+  "optionsIsolationSettingsNever": {
+    "message": "Never"
   }
 }

--- a/src/ui/components/domainpattern.vue
+++ b/src/ui/components/domainpattern.vue
@@ -1,7 +1,8 @@
 <script lang="ts">
-import Vue from 'vue';
+import mixins from 'vue-typed-mixins';
+import { mixin } from '~/ui/mixin';
 
-export default Vue.extend({
+export default mixins(mixin).extend({
   props: {
     id: {
       type: String,
@@ -48,11 +49,11 @@ export default Vue.extend({
   >
     <label>
       <span v-if="!exclusion">
-        <span v-if="!glossary">Domain Pattern</span>
+        <span v-if="!glossary">{{ t('optionsDomainPattern') }}</span>
         <span v-else data-glossary="Domain Pattern" />
       </span>
       <span v-else>
-        Exclusion Pattern
+        {{ t('optionsExclusionPattern') }}
       </span>
     </label>
     <input :id="id" v-model="domainPattern" type="text" />

--- a/src/ui/components/isolation/global.vue
+++ b/src/ui/components/isolation/global.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
-import Vue from 'vue';
-
+import mixins from 'vue-typed-mixins';
+import { mixin } from '~/ui/mixin';
 import DomainPattern from '../domainpattern.vue';
 import Settings from './settings.vue';
 import { App } from '~/ui/root';
 
-export default Vue.extend({
+export default mixins(mixin).extend({
   components: {
     DomainPattern,
     Settings,
@@ -84,8 +84,8 @@ export default Vue.extend({
     });
     $('#isolationGlobalExcludeContainers').dropdown({
       placeholder: !this.popup
-        ? 'Select Permanent Containers to Exclude from Isolation'
-        : 'Permanent Containers to Exclude',
+        ? this.t('optionsIsolationGlobalSelectExclusionContainers')
+        : this.t('optionsIsolationGlobalExclusionPermanentContainers'),
       values: excludeContainers,
       onAdd: (addedContainer) => {
         if (
@@ -141,7 +141,7 @@ export default Vue.extend({
           <div class="title">
             <h4>
               <i class="dropdown icon" />
-              Navigation
+              {{ t('optionsIsolationNavigation') }}
             </h4>
           </div>
           <div
@@ -149,7 +149,7 @@ export default Vue.extend({
             :class="{ 'ui segment': !popup, 'popup-margin': popup }"
           >
             <settings
-              label="Target Domain"
+              :label="t('optionsIsolationTargetDomain')"
               :action.sync="preferences.isolation.global.navigation.action"
             />
           </div>
@@ -158,7 +158,7 @@ export default Vue.extend({
           <div class="title">
             <h4>
               <i class="dropdown icon" />
-              Mouse Click
+              {{ t('optionsIsolationMouseClick') }}
             </h4>
           </div>
           <div
@@ -166,19 +166,19 @@ export default Vue.extend({
             :class="{ 'ui segment': !popup, 'popup-margin': popup }"
           >
             <settings
-              label="Middle Mouse"
+              :label="t('optionsIsolationMouseClickMiddleMouse')"
               :action.sync="
                 preferences.isolation.global.mouseClick.middle.action
               "
             />
             <settings
-              label="Ctrl/Cmd+Left Mouse"
+              :label="t('optionsIsolationMouseClickCtrlLeftMouse')"
               :action.sync="
                 preferences.isolation.global.mouseClick.ctrlleft.action
               "
             />
             <settings
-              label="Left Mouse"
+              :label="t('optionsIsolationMouseClickLeftMouse')"
               :action.sync="preferences.isolation.global.mouseClick.left.action"
             />
           </div>
@@ -187,7 +187,7 @@ export default Vue.extend({
           <div class="title">
             <h4>
               <i class="dropdown icon" />
-              Exclude Permanent Containers
+              {{ t('optionsIsolationGlobalExcludePermanentContainers') }}
             </h4>
           </div>
           <div
@@ -210,7 +210,7 @@ export default Vue.extend({
           <div class="title">
             <h4>
               <i class="dropdown icon" />
-              Exclude Target Domains
+              {{ t('optionsIsolationExcludeTargetDomains') }}
             </h4>
           </div>
           <div
@@ -229,7 +229,7 @@ export default Vue.extend({
                 />
                 <div class="field">
                   <button class="ui button primary">
-                    Exclude
+                    {{ t('optionsIsolationExclude') }}
                   </button>
                 </div>
               </form>
@@ -239,7 +239,7 @@ export default Vue.extend({
                     !Object.keys(preferences.isolation.global.excluded).length
                   "
                 >
-                  No domains excluded
+                  {{ t('optionsIsolationNoDomainsExcluded') }}
                 </div>
                 <div v-else>
                   <div
@@ -249,7 +249,12 @@ export default Vue.extend({
                   >
                     <div style="margin-top: 5px;" />
                     <span
-                      :data-tooltip="`Remove ${excludedDomainPattern}`"
+                      :data-tooltip="
+                        t(
+                          'optionsIsolationPerDomainRemove',
+                          excludedDomainPattern
+                        )
+                      "
                       data-position="right center"
                       style="color: red; cursor: pointer;"
                       @click="removeExcludedDomain(excludedDomainPattern)"

--- a/src/ui/components/isolation/mac.vue
+++ b/src/ui/components/isolation/mac.vue
@@ -1,8 +1,9 @@
 <script lang="ts">
-import Vue from 'vue';
 import { App } from '~/ui/root';
+import mixins from 'vue-typed-mixins';
+import { mixin } from '~/ui/mixin';
 
-export default Vue.extend({
+export default mixins(mixin).extend({
   props: {
     app: {
       type: Object as () => App,
@@ -31,11 +32,10 @@ export default Vue.extend({
         class="ui fluid dropdown"
       >
         <option value="disabled">
-          Disabled
+          {{ t('optionsIsolationDisabled') }}
         </option>
         <option value="enabled">
-          Isolate Navigations in Permanent Containers whose Target Domain isn't
-          MAC-"Always open in" assigned to that container
+          {{ t('optionsIsolationMacIsolateNonMac') }}
         </option>
       </select>
     </div>

--- a/src/ui/components/isolation/perdomain.vue
+++ b/src/ui/components/isolation/perdomain.vue
@@ -156,11 +156,11 @@ export default mixins(mixin).extend({
           rules: [
             {
               type: 'empty',
-              prompt: "Domain Pattern can't be empty",
+              prompt: this.t('optionsIsolationPerDomainPatternNoEmpty'),
             },
             {
               type: 'domainPattern',
-              prompt: 'Domain Pattern already exists',
+              prompt: this.t('optionsIsolationPerDomainPatternExists'),
             },
           ],
         },
@@ -262,9 +262,9 @@ export default mixins(mixin).extend({
 
     remove(index: number, pattern: string): void {
       if (
-        window.confirm(`
-        Remove ${pattern}?
-      `)
+        window.confirm(
+          this.t('optionsIsolationPerDomainRemoveConfirmation', pattern)
+        )
       ) {
         this.$delete(this.preferences.isolation.domain, index);
         if (this.editing && this.domain.pattern === pattern) {
@@ -342,7 +342,7 @@ export default mixins(mixin).extend({
         <div class="title">
           <h4>
             <i class="dropdown icon" />
-            Always open in
+            {{ t('optionsIsolationPerDomainAlwaysOpenIn') }}
           </h4>
         </div>
         <div
@@ -356,10 +356,10 @@ export default mixins(mixin).extend({
               class="ui fluid dropdown"
             >
               <option value="disabled">
-                Disabled
+                {{ t('optionsIsolationDisabled') }}
               </option>
               <option value="enabled">
-                Enabled
+                {{ t('optionsIsolationEnabled') }}
               </option>
             </select>
             <div v-show="domain.always.action === 'enabled'">
@@ -371,8 +371,8 @@ export default mixins(mixin).extend({
                 <label>
                   {{
                     !popup
-                      ? 'Disable if Navigation in Permanent Containers'
-                      : 'Disable in Permanent Containers'
+                      ? t('optionsIsolationPerDomainDisableIfNavPermContainer')
+                      : t('optionsIsolationPerDomainDisableIfPermContainer')
                   }}
                 </label>
               </div>
@@ -385,8 +385,8 @@ export default mixins(mixin).extend({
                 <label>
                   {{
                     !popup
-                      ? 'Disable if Navigation in Temporary Containers'
-                      : 'Disable in Temporary Containers'
+                      ? t('optionsIsolationPerDomainDisableIfNavTempContainer')
+                      : t('optionsIsolationPerDomainDisableIfTempContainer')
                   }}
                 </label>
               </div>
@@ -396,7 +396,7 @@ export default mixins(mixin).extend({
         <div class="title">
           <h4>
             <i class="dropdown icon" />
-            Navigation
+            {{ t('optionsIsolationNavigation') }}
           </h4>
         </div>
         <div
@@ -404,7 +404,7 @@ export default mixins(mixin).extend({
           :class="{ 'ui segment': !popup, 'popup-margin': popup }"
         >
           <settings
-            label="Target Domain"
+            :label="t('optionsIsolationTargetDomain')"
             :perdomain="true"
             :action.sync="domain.navigation.action"
           />
@@ -412,7 +412,7 @@ export default mixins(mixin).extend({
         <div class="title">
           <h4>
             <i class="dropdown icon" />
-            Mouse Click
+            {{ t('optionsIsolationMouseClick') }}
           </h4>
         </div>
         <div
@@ -420,17 +420,17 @@ export default mixins(mixin).extend({
           :class="{ 'ui segment': !popup, 'popup-margin': popup }"
         >
           <settings
-            label="Middle Mouse"
+            :label="t('optionsIsolationMouseClickMiddleMouse')"
             :perdomain="true"
             :action.sync="domain.mouseClick.middle.action"
           />
           <settings
-            label="Ctrl/Cmd+Left Mouse"
+            :label="t('optionsIsolationMouseClickCtrlLeftMouse')"
             :perdomain="true"
             :action.sync="domain.mouseClick.ctrlleft.action"
           />
           <settings
-            label="Left Mouse"
+            :label="t('optionsIsolationMouseClickLeftMouse')"
             :perdomain="true"
             :action.sync="domain.mouseClick.left.action"
           />
@@ -438,7 +438,7 @@ export default mixins(mixin).extend({
         <div class="title">
           <h4>
             <i class="dropdown icon" />
-            Exclude Target Domains
+            {{ t('optionsIsolationExcludeTargetDomains') }}
           </h4>
         </div>
         <div
@@ -458,13 +458,13 @@ export default mixins(mixin).extend({
                 />
                 <div class="field">
                   <button class="ui button primary">
-                    Exclude
+                    {{ t('optionsIsolationExclude') }}
                   </button>
                 </div>
               </form>
               <div style="margin-top: 20px;">
                 <div v-if="!Object.keys(domain.excluded).length">
-                  No Domains Excluded
+                  {{ t('optionsIsolationNoDomainsExcluded') }}
                 </div>
                 <div v-else>
                   <div
@@ -473,7 +473,12 @@ export default mixins(mixin).extend({
                   >
                     <div style="margin-top: 5px;" />
                     <span
-                      :data-tooltip="Remove"
+                      :data-tooltip="
+                        t(
+                          'optionsIsolationPerDomainRemove',
+                          excludedDomainPattern
+                        )
+                      "
                       style="margin-top: 10px; color: red; cursor: pointer;"
                       @click="removeExcludedDomain(excludedDomainPattern)"
                     >
@@ -501,10 +506,14 @@ export default mixins(mixin).extend({
               <i class="check circle icon" />
               Saved
             </span>
-            <span v-if="!saved"> Done editing {{ domain.pattern }} </span>
+            <span v-if="!saved">
+              {{ t('optionsIsolationPerDomainDoneEditing', domain.pattern) }}
+            </span>
           </transition>
         </span>
-        <span v-else> Add {{ domain.pattern }} </span>
+        <span v-else>
+          {{ t('optionsIsolationPerDomainAdd', domain.pattern) }}
+        </span>
       </button>
     </div>
     <br />
@@ -514,7 +523,7 @@ export default mixins(mixin).extend({
         style="margin-top: 10px;"
         :class="{ content: popup }"
       >
-        No Isolated Domains added yet
+        {{ t('optionsIsolationPerDomainNoIsolatedDomainsAdded') }}
       </div>
       <div v-else :class="{ content: popup }">
         <div :class="{ title: popup }">
@@ -531,7 +540,7 @@ export default mixins(mixin).extend({
               v-model="isolationDomainFilter"
               type="text"
               size="15"
-              placeholder="Filter Isolated Domains"
+              :placeholder="t('optionsIsolationPerDomainFilterIsolatedDomains')"
               @focus="expandIsolationDomainFilter"
               @click="expandIsolationDomainFilter"
             />
@@ -541,7 +550,7 @@ export default mixins(mixin).extend({
             />
           </span>
           <span v-else>
-            <strong>Isolated Domains</strong>
+            <strong>{{ t('optionsIsolationPerDomainIsolatedDomains') }}</strong>
           </span>
         </div>
         <div :class="{ content: popup }">
@@ -556,7 +565,9 @@ export default mixins(mixin).extend({
               :key="isolatedDomain.pattern"
             >
               <span
-                :data-tooltip="`Edit ${isolatedDomain.pattern}`"
+                :data-tooltip="
+                  t('optionsIsolationPerDomainEdit', isolatedDomain.pattern)
+                "
                 style="cursor: pointer;"
                 data-position="right center"
                 @click="edit(isolatedDomain._index)"
@@ -564,7 +575,9 @@ export default mixins(mixin).extend({
                 <i class="icon-pencil" style="color: #2185d0;" />
               </span>
               <span
-                :data-tooltip="`Remove ${isolatedDomain.pattern}`"
+                :data-tooltip="
+                  t('optionsIsolationPerDomainRemove', isolatedDomain.pattern)
+                "
                 data-position="right center"
                 style="color: red; cursor: pointer;"
                 @click="remove(isolatedDomain._index, isolatedDomain.pattern)"
@@ -574,7 +587,7 @@ export default mixins(mixin).extend({
               <span
                 :data-tooltip="
                   !popup && isolationDomains.length > 1
-                    ? 'Drag up/down - First in the list matches first'
+                    ? t('optionsIsolationPerDomainDragTooltip')
                     : undefined
                 "
                 data-position="right center"

--- a/src/ui/components/isolation/settings.vue
+++ b/src/ui/components/isolation/settings.vue
@@ -1,7 +1,8 @@
 <script lang="ts">
-import Vue from 'vue';
+import mixins from 'vue-typed-mixins';
+import { mixin } from '~/ui/mixin';
 
-export default Vue.extend({
+export default mixins(mixin).extend({
   props: {
     action: {
       type: String,
@@ -47,19 +48,19 @@ export default Vue.extend({
     </label>
     <select v-model="action" class="ui fluid dropdown">
       <option v-if="perdomain" value="global">
-        Use Global
+        {{ t('optionsIsolationSettingsGlobal') }}
       </option>
       <option value="never">
-        Never
+        {{ t('optionsIsolationSettingsNever') }}
       </option>
       <option value="notsamedomain">
-        Different from Tab Domain & Subdomains
+        {{ t('optionsIsolationSettingsNotSameDomain') }}
       </option>
       <option value="notsamedomainexact">
-        Different from Tab Domain
+        {{ t('optionsIsolationSettingsNotSameDomainExact') }}
       </option>
       <option value="always">
-        Always
+        {{ t('optionsIsolationSettingsAlways') }}
       </option>
     </select>
   </div>

--- a/src/ui/components/popup.vue
+++ b/src/ui/components/popup.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
-import Vue from 'vue';
-
+import mixins from 'vue-typed-mixins';
+import { mixin } from '~/ui/mixin';
 import IsolationGlobal from './isolation/global.vue';
 import IsolationPerDomain from './isolation/perdomain.vue';
 import IsolationMac from './isolation/mac.vue';
@@ -11,7 +11,7 @@ import Breadcrumb from './breadcrumb.vue';
 import Glossary from './glossary/index.vue';
 import { App } from '../root';
 
-export default Vue.extend({
+export default mixins(mixin).extend({
   components: {
     IsolationGlobal,
     IsolationPerDomain,
@@ -208,15 +208,15 @@ export default Vue.extend({
             <message />
 
             <div class="ui tab" data-tab="isolation-global">
-              <breadcrumb tab="Global" />
+              <breadcrumb :tab="t('optionsIsolationTabGlobal')" />
               <isolation-global :app="app" />
             </div>
             <div class="ui tab" data-tab="isolation-per-domain">
-              <breadcrumb tab="Per Domain" />
+              <breadcrumb :tab="t('optionsIsolationTabPerDomain')" />
               <isolation-per-domain :app="app" />
             </div>
             <div class="ui tab" data-tab="isolation-mac">
-              <breadcrumb tab="Multi-Account Containers" />
+              <breadcrumb :tab="t('optionsIsolationTabMac')" />
               <isolation-mac :app="app" />
             </div>
             <div class="ui tab" data-tab="actions">


### PR DESCRIPTION
Wondering if can't use simpler keys (e.g. "mouseClick" over "optionsIsolationMouseClick").

At the moment they give some context, but we could limit use of them to strings only used in once place (e.g. "No Isolated Domains added yet").

We could use the description tag for ambiguous strings, for example:
```json
"save": {
  "message": "Save",
  "description": "verb"
}
```
Or perhaps even:
```json
"verbSave": {
  "message": "Save"
}
```

Bit of a pain when you add "optionsIsolationPerDomainMouseClickLeftMouse" and then find it's actually used elsewhere too.