### PR TITLE
Specify opener tab information to new temporary container tabs opened from links

### DIFF
--- a/src/background/container.ts
+++ b/src/background/container.ts
@@ -65,6 +65,7 @@ export class Container {
     dontPin = true,
     deletesHistory = false,
     macConfirmPage = false,
+    openerTab,
   }: TmpTabOptions): Promise<Tab | undefined> {
     if (request && request.requestId) {
       // we saw that request already
@@ -98,6 +99,7 @@ export class Container {
       dontPin,
       macConfirmPage,
       contextualIdentity,
+      openerTab,
     });
   }
 
@@ -165,6 +167,7 @@ export class Container {
     dontPin,
     macConfirmPage,
     contextualIdentity,
+    openerTab,
   }: {
     url?: string;
     tab?: Tab;
@@ -172,6 +175,7 @@ export class Container {
     dontPin?: boolean;
     macConfirmPage?: boolean;
     contextualIdentity: browser.contextualIdentities.ContextualIdentity;
+    openerTab?: Tab;
   }): Promise<Tab> {
     try {
       const newTabOptions: CreateTabOptions = {
@@ -212,7 +216,9 @@ export class Container {
         if (tab.pinned && !dontPin) {
           newTabOptions.pinned = true;
         }
-        if (tab.openerTabId) {
+        if (openerTab) {
+          newTabOptions.openerTabId = openerTab.id;
+        } else if (tab.openerTabId) {
           newTabOptions.openerTabId = tab.openerTabId;
         }
         if (tab.windowId) {

--- a/src/background/contextmenu.ts
+++ b/src/background/contextmenu.ts
@@ -30,6 +30,7 @@ export class ContextMenu {
           active: false,
           deletesHistory:
             this.pref.deletesHistory.automaticMode === 'automatic',
+          openerTab: tab,
         });
         break;
 
@@ -39,6 +40,7 @@ export class ContextMenu {
           url: info.linkUrl,
           active: false,
           deletesHistory: true,
+          openerTab: tab,
         });
         break;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ export interface TmpTabOptions {
   dontPin?: boolean;
   deletesHistory?: boolean;
   macConfirmPage?: boolean;
+  openerTab?: Tab;
 }
 
 export type IsolationAction =


### PR DESCRIPTION
I got a compatibility issue report https://github.com/piroor/treestyletab/issues/2720 about a combination of two extensions: [Tree Style Tab](https://addons.mozilla.org/firefox/addon/tree-style-tab/) and Temporary Container. After a research I've realized that Temporary Containers doesn't set any opener tab information to tabs even if they are explicitly opened from links. This PR appends ability to set opener tab information to new temporary container tab on such cases. How about this change?