### PR TITLE
add away.vk.com to redirector domains

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -56,6 +56,7 @@ export const REDIRECTOR_DOMAINS_DEFAULT = [
   't.co',
   'outgoing.prod.mozaws.net',
   'slack-redir.net',
+  'away.vk.com',
 ];
 
 export const formatBytes = (bytes: number, decimals = 2): string => {

--- a/src/ui/components/advanced/general.vue
+++ b/src/ui/components/advanced/general.vue
@@ -376,7 +376,8 @@ export default mixins(mixin).extend({
               >Automatically close leftover redirector tabs after 2 seconds:
               <strong>t.co</strong> (Twitter),
               <strong>outgoing.prod.mozaws.net</strong> (AMO),
-              <strong>slack-redir.net</strong> (Slack)</label
+              <strong>slack-redir.net</strong> (Slack),
+              <strong>away.vk.com</strong> (VK)</label
             >
           </div>
         </div>


### PR DESCRIPTION
Add support of `away.vk.com`, which is a redirector domain used by vk.com (russian social network).